### PR TITLE
Ignore sqlite WAL/SHM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 ops_board/ops_board.sqlite
+ops_board/ops_board.sqlite-shm
+ops_board/ops_board.sqlite-wal
 reports/ops-board/


### PR DESCRIPTION
## Summary
- Ignore SQLite sidecar files created by the ops board DB

## Test plan
- Not applicable

## Related
- #13