### PR TITLE
Add session filters and search

### DIFF
--- a/ops_board/public/index.html
+++ b/ops_board/public/index.html
@@ -19,6 +19,20 @@
           <h2>Agents</h2>
           <p class="panel-meta">Select a session and send a task.</p>
         </div>
+        <div class="agent-filters">
+          <input
+            id="agent-search"
+            type="search"
+            placeholder="Search sessions..."
+            aria-label="Search sessions"
+          />
+          <select id="agent-filter" aria-label="Filter by agent">
+            <option value="">All agents</option>
+          </select>
+          <select id="source-filter" aria-label="Filter by source">
+            <option value="">All sources</option>
+          </select>
+        </div>
         <div id="agents-list" class="list"></div>
         <div class="agent-send">
           <div id="selected-agent" class="agent-selected">No session selected</div>

--- a/ops_board/public/styles.css
+++ b/ops_board/public/styles.css
@@ -119,6 +119,32 @@ h1 {
   min-height: auto;
 }
 
+.agent-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 12px 0 16px;
+}
+
+.agent-filters input,
+.agent-filters select {
+  background: #14110c;
+  color: var(--text);
+  border: 1px solid rgba(255, 230, 190, 0.2);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+.agent-filters input {
+  flex: 1;
+  min-width: 180px;
+}
+
+.agent-filters select {
+  min-width: 140px;
+}
+
 .list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes #24

## Summary
- add search input and agent/source filters
- filter sessions client-side by query + labels

## Plan
- **Plan doc**: `dev_plans/agentdeck-openclaw-gateway-multi-sessions.md`
- **Key decisions**:
  - client-side filtering for MVP

## Test plan
- [ ] Load UI and filter by agent/source
- [ ] Search by session title or id