### PR TITLE
Auto-detect OpenClaw session paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 ## Agent Maintenance
 - Update this file ad hoc when new tooling, scripts, or workflows are added so future runs stay optimal.
+- Use the browser tool to verify UI changes and report the outcome.
 
 ## Workflow & Agency
 - Default to executing requested work end-to-end unless a decision requires explicit approval.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Open `http://localhost:3333`.
 The UI reads sessions from a JSON file. By default:
 `ops_board/agent/sessions.json`
 
+If OpenClaw is installed, AgentDeck will automatically look for
+`~/.openclaw/agents/<agent>/sessions` (preferring `main`, then `main2`) before
+falling back to the repo default. Set `AGENT_SESSIONS_PATH` to override.
+
 To point at a different file:
 ```bash
 export AGENT_SESSIONS_PATH="/path/to/sessions.json"

--- a/ops_board/public/app.js
+++ b/ops_board/public/app.js
@@ -133,7 +133,9 @@ function renderAgents(sessions, error) {
 
     const title = document.createElement("div");
     title.className = "card-title";
-    title.textContent = session.title || session.id;
+    const titleText = session.title || session.id || "Session";
+    const agentPrefix = session.agent ? `${session.agent} · ` : "";
+    title.textContent = `${agentPrefix}${titleText}`;
     card.appendChild(title);
 
     const meta = document.createElement("div");
@@ -153,7 +155,11 @@ function renderAgents(sessions, error) {
     selectBtn.textContent = "Select";
     selectBtn.onclick = () => {
       selectedSessionId = session.id;
-      selectedAgent.textContent = `Selected: ${session.id}`;
+      if (session.agent) {
+        selectedAgent.textContent = `Selected: ${session.agent} · ${session.id}`;
+      } else {
+        selectedAgent.textContent = `Selected: ${session.id}`;
+      }
     };
     actions.appendChild(selectBtn);
     card.appendChild(actions);


### PR DESCRIPTION
Fixes #33

## Summary
- auto-detect OpenClaw sessions in `~/.openclaw/agents/<agent>/sessions`
- accept object-map session JSON payloads
- document auto-detection behavior in README

## Test plan
- [ ] Start UI without `AGENT_SESSIONS_PATH` and confirm sessions render