### PR TITLE
Add dev plans for core session + docs issues

### DIFF
--- a/dev_plans/agentdeck-agent-label-for-custom-session-paths.md
+++ b/dev_plans/agentdeck-agent-label-for-custom-session-paths.md
@@ -1,0 +1,139 @@
+# AgentDeck Plan: Agent label for custom sessions paths
+
+0) Executive Summary (5–10 lines)
+Objective: ensure sessions loaded from **custom `AGENT_SESSIONS_PATH`** are labeled with a stable agent name in the UI. Decision needed: confirm labeling strategy (explicit env var vs path inference) and whether the label should be required when a custom path is used, by **2026-02-04**. Problem: `ops_board/lib/agents.js` only infers agent names from the default `~/.openclaw/agents/<agent>` path; custom paths show no agent label, which degrades clarity in the sessions list. Proposal: add an explicit `AGENT_SESSIONS_LABEL` env var and expand path inference rules (parent directory name, `agents/<name>` patterns) to set `session.agent` consistently. Benefits: clearer UI, fewer ambiguous sessions, and more reliable filtering. Ask: approve the labeling policy so implementation can proceed.
+
+1) End‑user context
+- Primary user: Thupten (technical; sometimes points AgentDeck at non‑default session paths).
+- Goal: always know which agent a session belongs to.
+- Constraint: local‑only; minimal extra configuration.
+
+2) Requirements `R1..Rn`
+**User requirements**
+- UR1: Sessions loaded from custom paths show a stable agent label.
+- UR2: Labeling is deterministic and does not change between runs.
+
+**Functional requirements**
+- R1: Support an explicit `AGENT_SESSIONS_LABEL` env var that overrides inference.
+- R2: If no explicit label is provided, infer label from path heuristics.
+- R3: Propagate label to every session returned by `/api/agents`.
+
+**Non‑functional requirements**
+- NFR1: Backward compatible: default detection behavior remains for `~/.openclaw/agents/*`.
+- NFR2: Clear error/warning when label cannot be inferred and no override is provided.
+
+3) Non‑goals
+- NG1: No new UI controls for editing labels.
+- NG2: No changes to OpenClaw session schema.
+
+4) Success metrics (quantified)
+- SM1: 100% of sessions loaded from a custom path show a non‑empty `agent` label.
+- SM2: Zero regressions in default detection path (existing `main`/`main2`).
+
+5) Current repo state (repo‑grounded)
+- `inferAgentNameFromPath()` only recognizes `~/.openclaw/agents/<agent>` in `ops_board/lib/agents.js`.
+- `loadFileSessions()` uses `detectedAgentName` or `inferAgentNameFromPath()` and does **not** support an explicit override.
+- UI in `ops_board/public/app.js` displays `session.agent` if present.
+
+6) Architecture/system impact diagram (ASCII)
+```
+AGENT_SESSIONS_PATH + AGENT_SESSIONS_LABEL (env)
+            │
+            ▼
+ agents.js (label inference/override)
+            │
+            ▼
+     /api/agents -> UI
+```
+
+7) Assumptions & constraints
+- `AGENT_SESSIONS_PATH` may point to a file or directory.
+- Custom paths may be outside `~/.openclaw/agents` and may not encode agent name.
+- Error state: if no label can be inferred and no override is set, return sessions with `agent: null` and `error` message.
+
+8) Work breakdown `E1..En` mapping to `R*`
+- E1 (R1): Add `AGENT_SESSIONS_LABEL` env override in `loadFileSessions()`.
+  - Touchpoints: `ops_board/lib/agents.js`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E2 (R2): Expand `inferAgentNameFromPath()` heuristics.
+  - Heuristics: match `/.openclaw/agents/<name>`, `/agents/<name>/`, or parent dir name for `.../<agent>/sessions.json`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E3 (R3): Ensure label is applied uniformly across all session objects.
+  - Owner: TBD. Window: by 2026-02-06.
+
+9) Validation plan `V1..Vn` mapping to `R*` + success metrics
+- V1 (R1, SM1): Set `AGENT_SESSIONS_PATH=/tmp/custom/sessions.json` and `AGENT_SESSIONS_LABEL=custom`.
+  - Pass if: `/api/agents` returns sessions with `agent: "custom"`.
+- V2 (R2): Remove label env var and place file at `/tmp/agents/alpha/sessions.json`.
+  - Pass if: `/api/agents` returns `agent: "alpha"`.
+- V3 (NFR2): Use a custom path without label or inferable directory.
+  - Pass if: sessions load and `error` contains a label warning.
+
+10) Risks & mitigations
+- Risk: Incorrect path heuristics label the wrong agent.
+  - Mitigation: explicit override env var always wins.
+- Risk: Multiple agents in a single sessions file.
+  - Mitigation: out of scope; maintain label uniform per file.
+
+11) Top 10 reader questions (with answers or explicit follow‑up)
+1. Why not require a label for all custom paths? → Optional to keep setup minimal; warning if missing.
+2. Will this affect default detection? → No; default detection remains unchanged.
+3. What if I want multiple labels in one file? → Out of scope for this issue.
+4. How is label chosen if both env + path exist? → Env var wins.
+5. Does UI need updates? → No; it already displays `agent`.
+6. Can I override per session? → Not in this scope.
+7. Will this change Gateway behavior? → No; only file‑based sessions.
+8. Where is the label stored? → In the session object returned by `/api/agents`.
+9. Does this touch SQLite? → No.
+10. Can we add docs? → Yes, in README (optional follow‑up).
+
+12) Open questions
+- Q1: Should we **require** `AGENT_SESSIONS_LABEL` when a custom path is used?
+- Q2: Should we add a CLI flag instead of env var?
+
+13) Core PR vs Optional follow‑ups
+**Core PR (must‑do)**
+- `AGENT_SESSIONS_LABEL` override.
+- Path‑based inference improvements.
+- Error messaging when label missing.
+
+**Optional follow‑ups**
+- README updates documenting the label override.
+- UI badge styling for agent labels.
+
+14) Recommendation
+- Add `AGENT_SESSIONS_LABEL` override and keep inference as a best‑effort fallback.
+
+15) Next steps
+- Thupten: confirm whether `AGENT_SESSIONS_LABEL` is required for custom paths by **2026-02-04**.
+- Clawd: implement once confirmed.
+
+## Decision contracts
+- Contract A (label precedence): `AGENT_SESSIONS_LABEL` overrides all inference.
+- Contract B (inference scope): only filesystem path heuristics are used; no content sniffing.
+- Contract C (error signaling): missing label triggers a warning but does not block session load.
+
+## Current vs proposed schema/interface
+- Current: `/api/agents` returns sessions with `agent` set only when inferred from `~/.openclaw/agents/<agent>`.
+- Proposed: `/api/agents` sets `agent` from `AGENT_SESSIONS_LABEL` or path heuristics for any custom path.
+
+## State machine semantics (when applicable)
+Not applicable (label inference only).
+
+## WAF‑lite non‑functional posture
+- Principals/auth boundary: local filesystem; no external auth.
+- Security/privacy/compliance: read‑only access to session files.
+- Reliability: safe fallback if label missing.
+- Ops/observability: warning string in `/api/agents` if label missing.
+- Performance: O(n) per session list.
+- Cost posture: zero external cost.
+
+## Best‑practice references
+- Node.js FS API (path + file checks): https://nodejs.org/api/fs.html
+- Node.js Path API: https://nodejs.org/api/path.html
+- GitHub Docs (README configuration guidance): https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
+
+## Ready for Execution
+- [ ] Label policy confirmed (required vs optional).
+- [ ] Env var name confirmed (`AGENT_SESSIONS_LABEL`).
+- [ ] Inference heuristics accepted.

--- a/dev_plans/agentdeck-docs-polish-bundle.md
+++ b/dev_plans/agentdeck-docs-polish-bundle.md
@@ -1,0 +1,141 @@
+# AgentDeck Plan: Docs polish bundle (dev workflow + screenshots/GIF + snapshot contract)
+
+0) Executive Summary (5–10 lines)
+Objective: improve developer onboarding and user understanding by updating the README with a clear dev workflow, adding screenshots/GIF demo, and documenting the snapshot data contract with a sample JSON file. Decision needed: confirm the demo asset format (GIF vs MP4) and preferred screenshot locations by **2026-02-04**. Problem: the current README is minimal and does not show how to develop, what Node version to use, or what the snapshot output format looks like; there are no visuals of the UI. Proposal: add a “Development” section (node version, scripts, validate), a “UI preview” section with screenshots + GIF, and a “Snapshot contract” section linking to `ops_board/schema.md` and a sample JSON under `reports/ops-board/`. Benefits: faster setup, fewer support questions, and better project credibility. Ask: approve scope + demo asset format so the PR can be merged.
+
+1) End‑user context
+- Primary users: contributors (setup/dev) and readers evaluating AgentDeck.
+- Goals: quick local setup, clear UI expectations, and known snapshot schema.
+- Constraint: README should remain concise; deeper details can live in docs or sample files.
+
+2) Requirements `R1..Rn`
+**User requirements**
+- UR1: A developer can get to “UI running” with a clear set of commands.
+- UR2: README shows what the UI looks like.
+- UR3: Snapshot schema is documented with an example JSON file.
+
+**Functional requirements**
+- R1: Add a “Development” section (Node version, install, run, validate) to README.
+- R2: Add screenshots + demo GIF (or MP4) stored in repo (e.g., `docs/media/`).
+- R3: Add a “Snapshot contract” section referencing `ops_board/schema.md` and linking a sample JSON.
+
+**Non‑functional requirements**
+- NFR1: Assets should be lightweight (<= 10 MB total) to keep clone size reasonable.
+- NFR2: README remains concise (prefer links for deep details).
+
+3) Non‑goals
+- NG1: No UI redesign.
+- NG2: No changes to runtime behavior.
+- NG3: No external hosting of assets.
+
+4) Success metrics (quantified)
+- SM1: README contains explicit dev steps and a Node version requirement.
+- SM2: README shows at least 2 screenshots + 1 short demo (GIF/MP4).
+- SM3: Sample snapshot JSON exists at `reports/ops-board/sample.json` (or equivalent) and matches schema.
+
+5) Current repo state (repo‑grounded)
+- README includes basic setup and env vars but lacks dev workflow details and visuals.
+- Snapshot schema is documented in `ops_board/schema.md` but not referenced in README.
+- Snapshots are written to `reports/ops-board/YYYY-MM-DD.json` per README.
+
+6) Architecture/system impact diagram (ASCII)
+```
+README.md
+  ├─ Development (node version + commands)
+  ├─ UI preview (screenshots/GIF)
+  └─ Snapshot contract -> ops_board/schema.md + reports/ops-board/sample.json
+```
+
+7) Assumptions & constraints
+- Node version: README currently states Node.js 18+; we’ll align with Node LTS guidance.
+- Snapshot sample JSON should be derived from an actual run or a curated minimal example.
+- Asset storage path: `docs/media/` or `reports/media/` (decision needed).
+
+8) Work breakdown `E1..En` mapping to `R*`
+- E1 (R1): Expand README with “Development” section and scripts list (`npm start`, `npm run ingest:dry`, `npm run snapshot`, `npm run validate`).
+  - Touchpoints: `README.md`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E2 (R2): Capture 2 screenshots + 1 short demo GIF (or MP4) and add to README.
+  - Touchpoints: `docs/media/` (new), `README.md`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E3 (R3): Add “Snapshot contract” section linking `ops_board/schema.md` and sample JSON file.
+  - Touchpoints: `README.md`, `reports/ops-board/sample.json`.
+  - Owner: TBD. Window: by 2026-02-06.
+
+9) Validation plan `V1..Vn` mapping to `R*` + success metrics
+- V1 (R1, SM1): README includes explicit Node version and dev commands.
+  - Pass if: “Development” section lists Node version + install/run/validate commands.
+- V2 (R2, SM2): README renders screenshots and demo asset.
+  - Pass if: images render on GitHub; assets are in repo.
+- V3 (R3, SM3): Sample snapshot JSON validates against schema fields.
+  - Pass if: JSON includes required fields from `ops_board/schema.md` and matches documented structure.
+
+10) Risks & mitigations
+- Risk: Assets are too large.
+  - Mitigation: compress GIF/MP4, keep total <= 10 MB.
+- Risk: Snapshot sample diverges from schema.
+  - Mitigation: generate sample from actual snapshot output and trim.
+
+11) Top 10 reader questions (with answers or explicit follow‑up)
+1. What Node version do I need? → Document Node LTS (18+ or specific LTS).
+2. How do I run the UI? → `npm install` + `npm start` with `PORT` default.
+3. What does the UI look like? → Screenshots + demo.
+4. Where are snapshots stored? → `reports/ops-board/`.
+5. What’s the snapshot schema? → Link to `ops_board/schema.md` + sample JSON.
+6. Are there tests? → `npm run validate` (documented).
+7. Can I use a different DB path? → Already documented env var `DB_PATH`.
+8. Does this require Gateway? → No; file sessions supported.
+9. Where do I put images? → `docs/media/` (decision needed).
+10. Are assets hosted externally? → No; stored in repo.
+
+12) Open questions
+- Q1: Prefer GIF or MP4 for demo? (GitHub supports both.)
+- Q2: Preferred asset path: `docs/media/` or `reports/media/`?
+- Q3: Should README pin exact Node version or keep “18+”?
+
+13) Core PR vs Optional follow‑ups
+**Core PR (must‑do)**
+- README Development section (Node version + commands).
+- README UI preview (2 screenshots + 1 demo asset).
+- Snapshot contract section + sample JSON file.
+
+**Optional follow‑ups**
+- Add a “Troubleshooting” section for common env var issues.
+- Add `CONTRIBUTING.md` with workflow and style notes.
+
+14) Recommendation
+- Use `docs/media/` for assets and a short MP4 (smaller than GIF) unless you explicitly want GIF.
+
+15) Next steps
+- Thupten: confirm demo asset format and asset path by **2026-02-04**.
+- Clawd: update README + add assets + sample JSON.
+
+## Decision contracts
+- Contract A (asset storage): assets live in `docs/media/` and are referenced in README.
+- Contract B (node version): README states Node LTS and matches `package.json` engines if added.
+- Contract C (snapshot example): sample JSON must include required schema fields from `ops_board/schema.md`.
+
+## Current vs proposed schema/interface
+- Current: README does not reference `ops_board/schema.md` or provide a sample snapshot JSON.
+- Proposed: README includes a Snapshot Contract section linking schema + sample JSON; dev workflow section added.
+
+## State machine semantics (when applicable)
+Not applicable (documentation only).
+
+## WAF‑lite non‑functional posture
+- Principals/auth boundary: no change.
+- Security/privacy/compliance: sample JSON should contain scrubbed data.
+- Reliability: doc changes only.
+- Ops/observability: doc changes only.
+- Performance: asset sizes kept <= 10 MB.
+- Cost posture: zero external cost.
+
+## Best‑practice references
+- GitHub Docs on README content: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes
+- Node.js FS API (if referencing local file paths in docs): https://nodejs.org/api/fs.html
+- Node.js release guidance: https://nodejs.org/en/about/previous-releases
+
+## Ready for Execution
+- [ ] Demo asset format confirmed (GIF vs MP4).
+- [ ] Asset directory confirmed.
+- [ ] Node version policy confirmed (exact vs “18+”).

--- a/dev_plans/agentdeck-gateway-down-fallback.md
+++ b/dev_plans/agentdeck-gateway-down-fallback.md
@@ -1,0 +1,144 @@
+# AgentDeck Plan: Gateway down fallback (optional)
+
+0) Executive Summary (5–10 lines)
+Objective: make Gateway‑down behavior explicit and safe by providing an **optional file‑based fallback** with clear UI messaging and predictable error semantics. Decision needed: confirm whether fallback should be **opt‑in** via `OPENCLAW_GATEWAY_FALLBACK` (current env) or enabled by default when Gateway is unreachable, by **2026-02-04**. Problem: when the Gateway is enabled but unavailable, the UI can show empty sessions; the fallback path exists in code but requires clearer semantics, UI messaging, and validation coverage. Proposal: formalize fallback behavior, surface error state in UI, and document the expected env flags. Benefits: fewer “blank session list” failures, safer offline operation, and clearer debugging. Ask: approve fallback semantics so implementation can proceed.
+
+1) End‑user context
+- Primary user: Thupten (technical; may run AgentDeck while Gateway is down or restarting).
+- Goal: still see sessions if possible and understand when data is stale or fallback.
+- Constraint: local‑only; avoid surprising auto‑switches unless explicitly enabled.
+
+2) Requirements `R1..Rn`
+**User requirements**
+- UR1: When Gateway is down, the UI shows a clear warning.
+- UR2: If fallback is enabled, file‑based sessions appear instead of an empty list.
+- UR3: The session list indicates its data source (gateway vs file).
+
+**Functional requirements**
+- R1: Preserve current env flag `OPENCLAW_GATEWAY_FALLBACK` as the toggle.
+- R2: When Gateway errors occur, return `{ sessions, error }` with error text and source metadata.
+- R3: Ensure fallback sessions are labeled `source: "file"` and include `agent` where possible.
+- R4: Update README with fallback behavior and env description.
+
+**Non‑functional requirements**
+- NFR1: No additional Gateway calls when fallback is enabled (avoid retries loops).
+- NFR2: Failure modes are explicit (HTTP 200 with error message and sessions list).
+
+3) Non‑goals
+- NG1: No automatic reconnection loop.
+- NG2: No multi‑gateway support.
+- NG3: No UI polling changes.
+
+4) Success metrics (quantified)
+- SM1: When Gateway is down and fallback enabled, sessions list is non‑empty within one refresh.
+- SM2: When Gateway is down and fallback disabled, sessions list is empty and UI shows an error.
+- SM3: 100% of fallback sessions include `source: "file"`.
+
+5) Current repo state (repo‑grounded)
+- `ops_board/lib/agents.js` already checks `OPENCLAW_GATEWAY_FALLBACK` and returns file sessions on error.
+- `ops_board/public/app.js` displays `Gateway error: ...` when `error` is present.
+- README documents `OPENCLAW_GATEWAY_FALLBACK` but does not define explicit behavior or UI semantics.
+
+6) Architecture/system impact diagram (ASCII)
+```
+Gateway enabled?
+   ├─ yes → sessions.list → normalize → (error?)
+   │                     └─ if fallback → file sessions
+   └─ no  → file sessions only
+
+/api/agents -> UI warning + sessions list
+```
+
+7) Assumptions & constraints
+- `OPENCLAW_GATEWAY_FALLBACK` already exists and is used as a boolean.
+- File sessions are available via `AGENT_SESSIONS_PATH` or default path.
+- Error states should not crash server; only adjust response payload.
+
+8) Work breakdown `E1..En` mapping to `R*`
+- E1 (R1–R3): Normalize fallback sessions with `source: "file"` and include `agent` label from file loader.
+  - Touchpoints: `ops_board/lib/agents.js`, `ops_board/public/app.js` (display label if needed).
+  - Owner: TBD. Window: by 2026-02-06.
+- E2 (R2): Ensure API response always includes `error` text when fallback is used due to Gateway failure.
+  - Touchpoints: `ops_board/lib/agents.js`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E3 (R4): Update README with explicit fallback semantics and example env usage.
+  - Touchpoints: `README.md`.
+  - Owner: TBD. Window: by 2026-02-06.
+
+9) Validation plan `V1..Vn` mapping to `R*` + success metrics
+- V1 (SM1): Set `OPENCLAW_GATEWAY_ENABLED=1` and `OPENCLAW_GATEWAY_FALLBACK=1`, point Gateway URL to a closed port.
+  - Pass if: `/api/agents` returns `error` plus file sessions with `source: "file"`.
+- V2 (SM2): Same as V1 but `OPENCLAW_GATEWAY_FALLBACK=0`.
+  - Pass if: `/api/agents` returns `error` and `sessions: []`.
+- V3 (SM3): Inspect sessions list and verify all fallback sessions have `source: "file"`.
+
+10) Risks & mitigations
+- Risk: Users assume fallback data is live Gateway data.
+  - Mitigation: UI warning + `source` label in metadata.
+- Risk: Error message is noisy during normal operations.
+  - Mitigation: only show error when Gateway fails and fallback is used/disabled.
+
+11) Top 10 reader questions (with answers or explicit follow‑up)
+1. Do we already have fallback? → Partial; this plan formalizes UI + docs + labels.
+2. Will this change Gateway mode? → Only error handling.
+3. Is fallback enabled by default? → Decision needed.
+4. How do I know I’m seeing fallback data? → Error banner + `source: file` label.
+5. Can I disable fallback? → Yes via `OPENCLAW_GATEWAY_FALLBACK=0`.
+6. Will it retry automatically? → No (out of scope).
+7. Is any data written? → No.
+8. Does this affect send actions? → No change to `/api/agents/:id/send`.
+9. What if file sessions are missing too? → Show empty list + error.
+10. Does this require new env vars? → No.
+
+12) Open questions
+- Q1: Should fallback be opt‑in (current) or opt‑out?
+- Q2: Should we surface a persistent UI badge indicating fallback mode?
+
+13) Core PR vs Optional follow‑ups
+**Core PR (must‑do)**
+- Formalize fallback response semantics.
+- Ensure source labeling for fallback sessions.
+- Update README with explicit behavior.
+
+**Optional follow‑ups**
+- Add a persistent UI badge (e.g., “Fallback mode”).
+- Add a manual “Retry Gateway” button.
+
+14) Recommendation
+- Keep fallback **opt‑in** via `OPENCLAW_GATEWAY_FALLBACK=1` to avoid silent mode switching.
+
+15) Next steps
+- Thupten: confirm fallback default behavior by **2026-02-04**.
+- Clawd: implement once confirmed.
+
+## Decision contracts
+- Contract A (fallback default): fallback is opt‑in unless explicitly enabled.
+- Contract B (error signaling): Gateway failure always returns `error` string in `/api/agents` response.
+- Contract C (source labeling): fallback sessions must set `source: "file"`.
+
+## Current vs proposed schema/interface
+- Current: `/api/agents` may return `error` and either empty or fallback sessions depending on env; session `source` is not guaranteed for file fallback.
+- Proposed: `/api/agents` always returns `error` on Gateway failure; fallback sessions are labeled `source: "file"` with agent label if available.
+
+## State machine semantics (when applicable)
+- Non‑terminal: `gateway_attempt` → `fallback_applied`.
+- Terminal: `gateway_failed_no_fallback` or `gateway_failed_with_fallback`.
+- Correction: user can enable fallback and re‑load to transition from `gateway_failed_no_fallback` to `gateway_failed_with_fallback`.
+
+## WAF‑lite non‑functional posture
+- Principals/auth boundary: unchanged (Gateway auth via env).
+- Security/privacy/compliance: no new data paths.
+- Reliability: explicit fallback mode improves resiliency.
+- Ops/observability: UI warning and API error fields.
+- Performance: no new polling or retries.
+- Cost posture: zero external cost.
+
+## Best‑practice references
+- MDN WebSocket error/close events: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event
+- MDN WebSocket close event: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event
+- OpenClaw Gateway docs (RPC over WS): https://docs.openclaw.ai/cli/gateway
+
+## Ready for Execution
+- [ ] Fallback default confirmed (opt‑in vs opt‑out).
+- [ ] UI error messaging copy approved.
+- [ ] Source labeling requirements accepted.

--- a/dev_plans/agentdeck-merge-sessions-across-agents.md
+++ b/dev_plans/agentdeck-merge-sessions-across-agents.md
@@ -1,0 +1,152 @@
+# AgentDeck Plan: Merge sessions across all detected agents
+
+0) Executive Summary (5–10 lines)
+Objective: merge file‑based OpenClaw sessions across **all detected agents** so the AgentDeck UI can list every local session in one view. Decision needed: confirm merge semantics (dedupe strategy + ordering) and whether to include only `~/.openclaw/agents/*` or also allow additional search roots by **2026-02-04**. Problem: `ops_board/lib/agents.js` currently detects a single agent path (prefers `main`, then `main2`) and returns only one sessions file, which hides other local agents. Proposal: scan all agent directories under `~/.openclaw/agents`, load each `sessions.json`, normalize, label with agent name, and return a merged list with deterministic ordering and stable IDs. Benefits: complete local visibility, fewer “missing session” confusions, and consistent agent labels across the UI. Ask: approve the plan and merge semantics so implementation can proceed.
+
+1) End‑user context
+- Primary user: Thupten (technical, uses multiple OpenClaw agents and needs a single control surface).
+- Goal: see every local agent session without manual path switching.
+- Constraint: local‑only; no gateway required; must be deterministic and safe if files are missing.
+
+2) Requirements `R1..Rn`
+**User requirements**
+- UR1: See sessions from all locally detected agents in one list.
+- UR2: Each session clearly shows its agent label.
+- UR3: Duplicates are prevented or clearly resolved.
+
+**Functional requirements**
+- R1: Detect **all** agent directories under `~/.openclaw/agents/` and load each `sessions.json` or `sessions/` directory.
+- R2: Normalize each session with `agent` populated from the agent directory name.
+- R3: Merge sessions into a single array with deterministic ordering (by `last_active` desc, fallback to `id`).
+- R4: Ensure ID stability for merged sessions (no accidental collisions).
+
+**Non‑functional requirements**
+- NFR1: No crashes if an agent’s session file is missing or unreadable; return an error note and continue.
+- NFR2: Merge should complete in <= 300ms for <= 500 sessions on a local machine.
+- NFR3: Zero changes required to OpenClaw repos or config.
+
+3) Non‑goals
+- NG1: No Gateway changes (file‑based only).
+- NG2: No session history expansion; only session list.
+- NG3: No automatic refresh daemon.
+
+4) Success metrics (quantified)
+- SM1: 100% of session files under `~/.openclaw/agents/*/sessions.json` appear in UI within one refresh.
+- SM2: UI renders merged list <= 2 seconds for <= 500 sessions (existing UI target).
+- SM3: Zero duplicate IDs in the merged list.
+
+5) Current repo state (repo‑grounded)
+- Session loading is in `ops_board/lib/agents.js`.
+  - `detectOpenClawSessionsPath()` returns **one** agent path, not all.
+  - `loadFileSessions()` loads a single file and applies `inferAgentNameFromPath()`.
+- UI renders `agent` if present in `ops_board/public/app.js`.
+
+6) Architecture/system impact diagram (ASCII)
+```
+~/.openclaw/agents/*/sessions(.json)
+          │
+          ▼
+  agents.js (multi‑scan + normalize + merge)
+          │
+          ▼
+      /api/agents
+          │
+          ▼
+      UI session list
+```
+
+7) Assumptions & constraints
+- `~/.openclaw/agents/<agent>/sessions.json` exists for each agent (or `sessions/` directory).
+- The per‑agent session records are JSON objects or `{ sessions: [...] }`.
+- Path assumptions: use `os.homedir()` in `ops_board/lib/agents.js`.
+- Error states: if a single agent file fails to parse, return a warning but include other agents.
+
+8) Work breakdown `E1..En` mapping to `R*`
+- E1 (R1): Add a multi‑agent discovery helper that returns all session paths + agent names.
+  - Touchpoints: `ops_board/lib/agents.js`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E2 (R2, R4): Normalize sessions with `{ id, agent, source }` and safe ID strategy.
+  - Touchpoints: `ops_board/lib/agents.js`.
+  - Owner: TBD. Window: by 2026-02-06.
+- E3 (R3): Merge + order sessions deterministically.
+  - Touchpoints: `ops_board/lib/agents.js`, `ops_board/public/app.js` (only if display tweaks needed).
+  - Owner: TBD. Window: by 2026-02-07.
+
+9) Validation plan `V1..Vn` mapping to `R*` + success metrics
+- V1 (R1, SM1): Create two agent directories with sessions and verify `/api/agents` returns both.
+  - Steps: set `OPENCLAW_GATEWAY_ENABLED=0`, hit `/api/agents`.
+  - Pass if: sessions from both agents are returned with correct `agent` label.
+- V2 (R3, SM3): Validate no duplicate IDs.
+  - Steps: log `new Set(sessions.map(s => s.id)).size`.
+  - Pass if: set size equals sessions length.
+- V3 (NFR1): Corrupt one agent’s JSON and verify others still load with error warning.
+  - Pass if: `/api/agents` includes `error` but still includes other agents.
+
+10) Risks & mitigations
+- Risk: ID collisions across agents (same `id` reused).
+  - Mitigation: namespace IDs with `agent` when collision detected (decision contract below).
+- Risk: Mixed session file shapes.
+  - Mitigation: keep existing tolerant parsing (`parseFirstJsonObject`) and add per‑file error isolation.
+
+11) Top 10 reader questions (with answers or explicit follow‑up)
+1. Will this change any OpenClaw files? → No, read‑only.
+2. How do we avoid duplicate IDs? → See Decision Contract A.
+3. What if an agent has no sessions file? → Skip with warning; continue.
+4. Will this be slower? → Target <= 300ms for <= 500 sessions.
+5. How is ordering decided? → `last_active` desc, then `id`.
+6. Does this affect Gateway mode? → No, only file‑based load path.
+7. Can we include custom paths too? → Out of scope here; see Issue #36 plan.
+8. Will UI changes be required? → Minimal; existing UI already shows `agent`.
+9. What if file contains multiple JSON objects? → Existing parser extracts first JSON object.
+10. Can we disable multi‑agent merging? → If needed, add env flag (TBD).
+
+12) Open questions
+- Q1: Should we namespace **all** IDs with `agent:` or only on collisions?
+- Q2: Should the discovery search only `~/.openclaw/agents/*` or also support extra roots?
+
+13) Core PR vs Optional follow‑ups
+**Core PR (must‑do)**
+- Multi‑agent discovery and merged session list.
+- Deterministic ordering and ID collision policy.
+- Error isolation per agent file.
+
+**Optional follow‑ups**
+- Add per‑agent summary counts in UI.
+- Add a `source` badge for file‑based sessions.
+
+14) Recommendation
+- Namespace IDs only on collision (minimizes disruption), and keep ordering by `last_active` desc.
+
+15) Next steps
+- Thupten: confirm ID collision policy and discovery scope by **2026-02-04**.
+- Clawd: draft implementation once confirmed.
+
+## Decision contracts
+- Contract A (ID semantics): session IDs remain unchanged unless a collision is detected; collisions are resolved by prefixing `${agent}:`.
+- Contract B (ordering): sessions ordered by `last_active` desc, then `id` asc.
+- Contract C (scope): only `~/.openclaw/agents/*` is scanned in v1 unless explicitly expanded.
+
+## Current vs proposed schema/interface
+- Current: `/api/agents` returns sessions from a **single** detected agent path.
+- Proposed: `/api/agents` returns a merged list across all detected agent paths, with `agent` set for each session.
+
+## State machine semantics (when applicable)
+Not applicable (read‑only list aggregation).
+
+## WAF‑lite non‑functional posture
+- Principals/auth boundary: local filesystem only; no external auth.
+- Security/privacy/compliance: read‑only access to `~/.openclaw/agents`.
+- Reliability: per‑file error isolation; never crash on one bad file.
+- Ops/observability: surface a warning string in `/api/agents` when a file fails.
+- Performance: O(n) scan; <= 300ms for <= 500 sessions.
+- Cost posture: zero external cost.
+
+## Best‑practice references
+- Node.js FS API (file reads): https://nodejs.org/api/fs.html
+- Node.js Path API: https://nodejs.org/api/path.html
+- Node.js Errors (error handling): https://nodejs.org/api/errors.html
+
+## Ready for Execution
+- [ ] ID collision policy confirmed (namespace on collision vs always).
+- [ ] Discovery scope confirmed (only `~/.openclaw/agents/*` vs expanded roots).
+- [ ] Performance target accepted (<= 300ms for <= 500 sessions).


### PR DESCRIPTION
## Summary
- Add development plans for issues #35, #36, #29, and docs bundle (#21/#20/#19).

## Related Issues
Related: #35, #36, #29, #21, #20, #19

## Plan Files
- dev_plans/agentdeck-merge-sessions-across-agents.md
- dev_plans/agentdeck-agent-label-for-custom-session-paths.md
- dev_plans/agentdeck-gateway-down-fallback.md
- dev_plans/agentdeck-docs-polish-bundle.md
