### PR TITLE
Plan: Mission Control v1 migration to Next.js + Convex + TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@ node_modules/
 ops_board/ops_board.sqlite
 ops_board/ops_board.sqlite-shm
 ops_board/ops_board.sqlite-wal
+ops_board/ops_board.e2e.sqlite*
+ops_board/ops_board.browser-smoke.sqlite*
 reports/ops-board/
+reports/browser-smoke/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -117,3 +117,15 @@ export OPENCLAW_SESSION_ID_FIELD="id"
 ```bash
 npm run validate
 ```
+
+## UI testing
+Run Playwright regression tests:
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
+Run browser automation smoke checks (requires `agent-browser` CLI):
+```bash
+npm run test:browser:smoke
+```

--- a/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
+++ b/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
@@ -37,6 +37,7 @@ Decision needed by: 2026-02-18 (today) to begin Phase 1 scaffolding and schema i
 - R7 (Memory): expose global search (text + semantic) and render source snippets.
 - R8 (Cross-cutting): maintain immutable activity log for all significant mutations.
 - R9 (Contracts): any agent-created work item must map to a task ID; any scheduled action must map to a job ID.
+- R10 (UI quality gates): any UI-affecting change must pass Playwright regression checks and a browser automation smoke flow before merge.
 
 ### Non-functional requirements
 - NFR1 Reliability: no silent failure states; failed jobs surface actionable errors.
@@ -189,6 +190,9 @@ Untrusted Inputs / Sources
 - E5 (R8, NFR1-6): health indicators, migration/backfill utility, and acceptance validation suite.
   - Artifacts: migration action/script, `/activity`, test checklist.
   - Owner: Clawd. Window: 2026-02-22.
+- E6 (R10): establish UI regression tooling and automation evidence workflow.
+  - Artifacts: Playwright config/specs, browser automation smoke script, CI-ready test commands.
+  - Owner: Clawd. Window: 2026-02-22.
 
 13) Validation plan `V1..Vn` mapping to `R*` + success metrics
 - V1 (R1/R2, SM1, SM4): task create/update/transition integration test.
@@ -206,6 +210,12 @@ Untrusted Inputs / Sources
 - V5 (NFR1/NFR6): failure-path test.
   - Simulate ingest and run failures.
   - Pass: UI shows failure state + actionable retry.
+- V6 (R10): Playwright UI regression suite for changed screens.
+  - Command: `npm run test:e2e`.
+  - Pass: all UI specs green on changed surfaces; artifacts saved on failure.
+- V7 (R10): browser automation smoke using `agent-browser` for realistic operator flow checks.
+  - Command: `npm run test:browser:smoke`.
+  - Pass: page opens, core controls are discoverable/interactable, and smoke screenshot evidence is captured.
 
 14) Risks & mitigations
 - Risk: migration churn if old and new systems diverge during build.
@@ -301,6 +311,7 @@ Proceed with a scope-locked v1 migration in this order: schema/contracts first, 
 - [ ] Task/job state machine contracts accepted.
 - [ ] Memory search citation requirement accepted.
 - [ ] Validation gates (SM1–SM5, V1–V5) accepted.
+- [ ] UI quality gates accepted: Playwright (`test:e2e`) + browser automation smoke (`test:browser:smoke`).
 
 ## Best-practice references
 - Next.js App Router docs: https://nextjs.org/docs/app

--- a/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
+++ b/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
@@ -1,0 +1,271 @@
+# AgentDeck Mission Control v1 (Next.js + Convex + TypeScript)
+
+0) Executive Summary (5–10 lines)
+Objective: migrate AgentDeck from the current Express + SQLite implementation to a Next.js + Convex + TypeScript Mission Control that reliably tracks tasks, schedules, and memory with auditable state changes. Ask/decision: approve this v1 scope and architecture so implementation can start on this issue branch immediately.
+
+Problem: the current repo provides a local ops board, but it is not aligned to the desired Mission Control operating model (shared task contracts, schedule observability, memory search-first UX) and does not use the requested stack.
+
+Proposal: build a lean v1 in Next.js App Router + Convex functions using TypeScript everywhere, with three core screens (Tasks, Scheduler, Memory), a shared activity log, and deterministic state-transition contracts. Use a phased migration so the existing app can remain usable until cutover.
+
+Benefits: a single source of operational truth, lower coordination friction between human and agent, deterministic cron visibility, and searchable memory with source traceability.
+
+Decision needed by: 2026-02-18 (today) to begin Phase 1 scaffolding and schema implementation.
+
+1) End-user context
+- Primary user: Thupten (technical founder/operator, prefers concise high-agency execution).
+- Technical level: advanced; comfortable with GitHub, local dev servers, and architecture tradeoffs.
+- User goals:
+  - See what is being worked on now, by whom, and why.
+  - Verify scheduled work exists and is running correctly.
+  - Search prior memory/conversation artifacts quickly with source references.
+- Workflow goal: treat OpenClaw + subagents as an operating system, not just a chat UI.
+
+2) Requirements `R1..Rn`
+### User requirements
+- UR1: one board for all active tasks with ownership and status.
+- UR2: one calendar/list view for scheduled jobs and run outcomes.
+- UR3: one memory view with keyword + semantic search and source traceability.
+- UR4: one audit timeline for all major mutations across tasks/jobs/memory.
+
+### Functional requirements
+- R1 (Tasks): create, edit, assign, reprioritize, and transition tasks through a constrained workflow.
+- R2 (Tasks): auto-log task lifecycle events with actor + before/after summaries.
+- R3 (Scheduler): create one-shot and recurring jobs with enabled/disabled state.
+- R4 (Scheduler): show next run, last run, latest status, and per-job run history.
+- R5 (Scheduler): support manual “run now”, pause/resume, edit, and delete.
+- R6 (Memory): ingest configured memory documents into indexable chunks.
+- R7 (Memory): expose global search (text + semantic) and render source snippets.
+- R8 (Cross-cutting): maintain immutable activity log for all significant mutations.
+- R9 (Contracts): any agent-created work item must map to a task ID; any scheduled action must map to a job ID.
+
+### Non-functional requirements
+- NFR1 Reliability: no silent failure states; failed jobs surface actionable errors.
+- NFR2 Performance: memory search p95 <= 1.5s at 100k chunks on local/dev target assumptions.
+- NFR3 Auditability: every mutation stores actor, timestamp, and diff summary.
+- NFR4 Consistency: exactly one canonical status per task and one canonical schedule per job.
+- NFR5 Safety: destructive operations require explicit confirmation and server-side authorization checks.
+- NFR6 Operability: system health indicators for blocked tasks, failed runs, and stale memory index.
+
+3) Non-goals
+- NG1: no “digital office/avatar simulation” in v1.
+- NG2: no automated thumbnail/media generation in v1.
+- NG3: no broad third-party integrations beyond required OpenClaw/cron/memory sources.
+- NG4: no multi-tenant org model; single-operator scope only.
+
+4) Success metrics (quantified)
+- SM1: 100% of newly created tasks appear in the Tasks view within 2 seconds.
+- SM2: 100% of job runs are visible with status + summary in run history.
+- SM3: search top results include source path citation for >= 95% of queries tested in acceptance set.
+- SM4: 0 uncaptured mutations in audit checks (all writes emit activity rows).
+- SM5: after app restart, scheduler/job definitions are unchanged (0 lost jobs in test set).
+
+5) Current repo state (repo-grounded)
+- `package.json`: Node app scripts (`start`, `snapshot`, `validate`) and dependencies (`express`, `better-sqlite3`, `ws`) indicate current architecture is Express + SQLite.
+- `ops_board/server.js`: current HTTP server entrypoint for the existing local ops board.
+- `ops_board/ops_board.sqlite`: persistent SQLite store for current implementation.
+- `ops_board/public/`: existing static UI assets.
+- `README.md`: documents local-first setup, source-path ingestion, and gateway/session configuration.
+- `dev_plans/agentdeck-personal-ops-board.md`: prior plan establishes local-first operational goals, which this migration preserves while upgrading stack + contracts.
+
+6) Architecture/system impact diagram (ASCII)
+```text
+Untrusted Inputs / Sources
+  ├─ OpenClaw task/job events
+  ├─ Cron/job outcomes
+  ├─ Memory markdown/doc files
+  └─ Existing AgentDeck data (SQLite backfill)
+                 │
+                 ▼
+      Next.js (App Router, TypeScript)
+  ├─ /tasks
+  ├─ /scheduler
+  ├─ /memory
+  └─ /activity
+                 │
+                 ▼
+         Convex Functions (TypeScript)
+  ├─ queries (read models)
+  ├─ mutations (write contracts)
+  ├─ actions (ingest/index/backfill)
+  └─ scheduler hooks + run recording
+                 │
+                 ▼
+             Convex Data Model
+  tasks, taskEvents, jobs, jobRuns,
+  memoryDocs, memoryChunks, activityLog
+```
+
+7) Assumptions & constraints
+- Stack is fixed for this project: Next.js + Convex + TypeScript.
+- Existing Express app can remain during migration (strangler approach) until parity is reached.
+- REPO_ROOT for this repo is `/Users/thuptenwangpo/Documents/GitHub/agentdeck`.
+- File-backed memory sources are treated as read-only ingest sources.
+- ID generation: Convex-generated IDs for primary entities; idempotency keys for ingest/backfill events.
+- Minimal error/empty states required:
+  - no tasks yet,
+  - no jobs scheduled,
+  - memory index empty/stale,
+  - ingest error with retry action.
+
+8) Decision contracts (locked semantics)
+- DC1 Workflow semantics: task status transitions are explicit and constrained by a state machine; no ad hoc status values.
+- DC2 Storage truth semantics: Convex is the canonical write/read store for v1 entities after cutover; SQLite is legacy/backfill source only.
+- DC3 Scheduling semantics: a job definition is durable and restart-safe; each run writes exactly one terminal outcome record.
+- DC4 Search semantics: memory search responses must include source references (path and snippet anchor) for trust and traceability.
+
+9) Current vs proposed schema/interface
+### Current
+- SQLite tables and local scripts (implicit schema in `ops_board/*`).
+- Express endpoints and static public UI.
+
+### Proposed (Convex collections)
+- `tasks`: title, description, ownerType, ownerId, status, priority, dueAt, createdAt, updatedAt, archivedAt.
+- `taskEvents`: taskId, eventType, actorType, actorId, beforeJson, afterJson, createdAt.
+- `jobs`: name, scheduleKind, scheduleExpr, timezone, payloadKind, payloadJson, enabled, nextRunAt, lastRunAt, createdAt, updatedAt.
+- `jobRuns`: jobId, startedAt, endedAt, status, summary, error, attempt.
+- `memoryDocs`: sourcePath, sourceType, title, checksum, createdAt, updatedAt.
+- `memoryChunks`: docId, chunkIndex, text, embedding, tokenCount.
+- `activityLog`: entityType, entityId, action, actorType, actorId, metadataJson, createdAt.
+
+### Proposed app interfaces
+- Next.js routes/pages: `/tasks`, `/scheduler`, `/memory`, `/activity`.
+- Convex API surface (query/mutation/actions) aligned to the entities above.
+
+10) State machine semantics (terminal vs non-terminal)
+### Task state machine
+- Non-terminal: `backlog`, `ready`, `in_progress`, `blocked`
+- Terminal: `done`, `archived`
+- Correction rules:
+  - `done -> in_progress` allowed only with `reopenedReason`.
+  - `archived` is terminal for active boards; unarchive requires explicit admin mutation.
+
+### Job run state machine
+- Non-terminal: `queued`, `running`
+- Terminal: `success`, `failed`, `timeout`, `canceled`
+- Correction/supersede rules:
+  - terminal rows are immutable;
+  - retries create new `jobRuns` row with incremented `attempt`;
+  - latest terminal run is computed view, not in-place overwrite.
+
+### Memory ingest state model
+- Non-terminal: `discovered`, `indexing`
+- Terminal: `indexed`, `ingest_failed`
+- Supersede rules:
+  - new checksum supersedes prior doc version via new ingest event;
+  - stale chunks remain query-excluded once superseded.
+
+11) WAF-lite non-functional posture
+- Security/authorization boundary: server-side mutation authorization in Convex; no client-trusted writes.
+- Privacy/compliance: memory sources stay local/project-scoped; no external exfiltration in v1.
+- Reliability: idempotent ingest/backfill and explicit terminal run states reduce duplicate/ghost writes.
+- Operational excellence/observability: activity log + health indicators + error surfaces with retry guidance.
+- Performance: indexed query patterns for list views and bounded result windows for search.
+- Cost posture: Convex usage expected low at v1 scale; monitor read/write hotspots before adding premium infra.
+
+12) Work breakdown `E1..En` mapping to `R*`
+- E1 (R1, R2, R8, R9): define Convex schema + status contracts + shared activity logging utilities.
+  - Artifacts: `convex/schema.ts`, task/event mutations, shared log helper.
+  - Owner: Clawd. Window: 2026-02-18.
+- E2 (R1, R2): implement Tasks screen and CRUD/transition mutations.
+  - Artifacts: `app/tasks/*`, typed hooks, state transition guards.
+  - Owner: Clawd. Window: 2026-02-19.
+- E3 (R3, R4, R5, R8): implement Scheduler screen, jobs CRUD, run history, run-now action.
+  - Artifacts: `app/scheduler/*`, `convex/jobs.ts`, `convex/jobRuns.ts`.
+  - Owner: Clawd. Window: 2026-02-20.
+- E4 (R6, R7, R8): implement Memory ingest/index/search with source-cited results.
+  - Artifacts: `app/memory/*`, `convex/memory*.ts`, ingest actions.
+  - Owner: Clawd. Window: 2026-02-21.
+- E5 (R8, NFR1-6): health indicators, migration/backfill utility, and acceptance validation suite.
+  - Artifacts: migration action/script, `/activity`, test checklist.
+  - Owner: Clawd. Window: 2026-02-22.
+
+13) Validation plan `V1..Vn` mapping to `R*` + success metrics
+- V1 (R1/R2, SM1, SM4): task create/update/transition integration test.
+  - Command: `npm run test:tasks` (or equivalent once scaffolded).
+  - Pass: task visible <=2s; matching activity rows emitted for each mutation.
+- V2 (R3/R4/R5, SM2, SM5): job lifecycle + run history test.
+  - Manual + scripted checks: create recurring + one-shot, run now, pause/resume.
+  - Pass: each run produces terminal row; restart retains all job definitions.
+- V3 (R6/R7, SM3): memory ingest/search acceptance set.
+  - Command: `npm run test:memory` with fixed query set.
+  - Pass: >=95% result rows include source citation path/snippet.
+- V4 (R8, NFR3): activity completeness audit.
+  - Command: `npm run audit:mutations`.
+  - Pass: 0 write mutations missing corresponding activity records.
+- V5 (NFR1/NFR6): failure-path test.
+  - Simulate ingest and run failures.
+  - Pass: UI shows failure state + actionable retry.
+
+14) Risks & mitigations
+- Risk: migration churn if old and new systems diverge during build.
+  - Mitigation: freeze new feature work in Express app after E1; only parity fixes.
+- Risk: memory search quality regressions due to poor chunking/indexing defaults.
+  - Mitigation: define deterministic chunking strategy and acceptance query set before launch.
+- Risk: scheduler duplication or ghost runs.
+  - Mitigation: idempotent run keys + immutable terminal run rows + restart tests.
+- Risk: scope creep into aesthetic/non-operational UI.
+  - Mitigation: enforce v1 scope gate (Tasks/Scheduler/Memory/Activity only).
+
+15) Top 10 reader questions (with answers or explicit follow-up)
+1. Why migrate instead of patching Express + SQLite?  
+   Because the requested stack is Next.js + Convex + TS, and v1 needs stronger real-time/state contracts than current scripts.
+2. Will this break current usage immediately?  
+   No. Strangler migration keeps current app usable until parity/cutover.
+3. Is Convex overkill for single-user ops?  
+   No for this case; it simplifies typed query/mutation consistency and live UI updates.
+4. How do we prevent dashboard theater?  
+   By enforcing event contracts and acceptance metrics tied to behavior, not visuals.
+5. What is the canonical store after cutover?  
+   Convex (locked by DC2).
+6. How do we verify scheduler correctness?  
+   Run lifecycle tests + restart durability checks (V2).
+7. How do we trust memory search output?  
+   Source-cited result requirement and acceptance set checks (V3).
+8. Can we still use legacy snapshots?  
+   Yes during migration; they are optional after Convex activity log is authoritative.
+9. What if requirements expand mid-build?  
+   Add to optional follow-ups unless they are critical defects.
+10. When do we consider v1 complete?  
+   When all acceptance criteria pass and scope-gated screens are stable.
+
+16) Open questions
+- OQ1: memory embedding provider/strategy for semantic search in local dev ([TODO] pick concrete provider).
+- OQ2: cutover trigger: date-based or acceptance-criteria-based switch ([TODO] default to acceptance-based).
+- OQ3: whether to preserve old SQLite read-only diagnostics page post-migration.
+
+17) Core PR vs Optional follow-ups
+### Core PR (must-do)
+- Next.js + TypeScript + Convex scaffold in this repo.
+- Convex schema + contracts for tasks/jobs/memory/activity.
+- UI screens: Tasks, Scheduler, Memory, Activity.
+- Migration/backfill utility from existing SQLite where needed.
+- Validation scripts/checklist for acceptance criteria.
+
+### Optional follow-ups
+- Content pipeline screen.
+- Team role map/subagent roster view.
+- Office/visual simulation layer.
+- Advanced analytics (throughput, SLA, trend charts).
+
+18) Recommendation
+Proceed with a scope-locked v1 migration in this order: schema/contracts first, then Tasks, Scheduler, Memory, then migration hardening. Keep visuals intentionally plain until behavioral reliability passes acceptance.
+
+19) Next steps
+1. Approve this plan and branch as the execution base (today, 2026-02-18).
+2. Start E1 scaffold and schema contracts.
+3. Open a draft PR titled: `Plan: Mission Control v1 migration to Next.js + Convex + TypeScript` linking this plan.
+
+## Ready for Execution
+- [ ] Scope approved: Tasks + Scheduler + Memory + Activity only.
+- [ ] Convex as canonical post-cutover store confirmed.
+- [ ] Task/job state machine contracts accepted.
+- [ ] Memory search citation requirement accepted.
+- [ ] Validation gates (SM1–SM5, V1–V5) accepted.
+
+## Best-practice references
+- Next.js App Router docs: https://nextjs.org/docs/app
+- Convex + Next.js quickstart: https://docs.convex.dev/quickstart/nextjs
+- Convex data modeling: https://docs.convex.dev/database/schemas
+- TypeScript handbook: https://www.typescriptlang.org/docs/
+- React docs (state, rendering, architecture): https://react.dev/learn
+- AWS Well-Architected Framework: https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html

--- a/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
+++ b/dev_plans/agentdeck-mission-control-nextjs-convex-v1.md
@@ -52,6 +52,17 @@ Decision needed by: 2026-02-18 (today) to begin Phase 1 scaffolding and schema i
 - NG3: no broad third-party integrations beyond required OpenClaw/cron/memory sources.
 - NG4: no multi-tenant org model; single-operator scope only.
 
+3.1) Source inspiration alignment (article -> product scope)
+- Article framing: “OpenClaw needs Mission Control” with Next.js + Convex stack.
+- Component mapping:
+  - Tasks Board -> v1 `/tasks` (core).
+  - Calendar (scheduled tasks/cron visibility) -> v1 `/scheduler` (core).
+  - Memory + global search -> v1 `/memory` (core).
+  - Content Pipeline -> v2 after v1 acceptance.
+  - Team (agent roster + role clarity) -> v2 after v1 acceptance.
+  - Office (avatar simulation) -> v3/optional only.
+- Rationale: this keeps the proactive-operating-system value from the article while avoiding v1 scope collapse.
+
 4) Success metrics (quantified)
 - SM1: 100% of newly created tasks appear in the Tasks view within 2 seconds.
 - SM2: 100% of job runs are visible with status + summary in run history.
@@ -230,8 +241,13 @@ Untrusted Inputs / Sources
 
 16) Open questions
 - OQ1: memory embedding provider/strategy for semantic search in local dev ([TODO] pick concrete provider).
-- OQ2: cutover trigger: date-based or acceptance-criteria-based switch ([TODO] default to acceptance-based).
+- OQ2: cutover trigger: date-based or acceptance-criteria-based switch.
 - OQ3: whether to preserve old SQLite read-only diagnostics page post-migration.
+
+16.1) Resolved decisions (locked)
+- RD1 (cutover): acceptance-criteria-based cutover only. No date-based cutover.
+- RD2 (v1 scope): tasks + scheduler + memory + activity only; content/team/office remain post-v1 phases.
+- RD3 (stack): Next.js App Router + Convex + TypeScript is mandatory for all new Mission Control surfaces.
 
 17) Core PR vs Optional follow-ups
 ### Core PR (must-do)
@@ -242,10 +258,16 @@ Untrusted Inputs / Sources
 - Validation scripts/checklist for acceptance criteria.
 
 ### Optional follow-ups
-- Content pipeline screen.
-- Team role map/subagent roster view.
+- Content pipeline screen (idea -> script -> thumbnail -> filming -> published, with attachments).
+- Team role map/subagent roster view (agent cards, roles, responsibilities, current load).
 - Office/visual simulation layer.
 - Advanced analytics (throughput, SLA, trend charts).
+
+17.1) Phase roadmap (inspired by article sequence)
+- Phase 1 (this plan): Tasks, Scheduler, Memory, Activity.
+- Phase 2: Content Pipeline + Team.
+- Phase 3: Office simulation and advanced visuals.
+- Gate rule: each phase starts only after prior phase acceptance checks pass.
 
 18) Recommendation
 Proceed with a scope-locked v1 migration in this order: schema/contracts first, then Tasks, Scheduler, Memory, then migration hardening. Keep visuals intentionally plain until behavioral reliability passes acceptance.
@@ -254,6 +276,24 @@ Proceed with a scope-locked v1 migration in this order: schema/contracts first, 
 1. Approve this plan and branch as the execution base (today, 2026-02-18).
 2. Start E1 scaffold and schema contracts.
 3. Open a draft PR titled: `Plan: Mission Control v1 migration to Next.js + Convex + TypeScript` linking this plan.
+
+20) Rollback plan (L1-required)
+- Trigger conditions:
+  - any critical data integrity defect in task/job status contracts;
+  - scheduler run recording misses terminal rows in validation;
+  - memory search fails traceability requirement repeatedly in acceptance set.
+- Rollback mechanism:
+  - keep existing Express + SQLite app runnable during migration;
+  - gate new Next.js Mission Control routes behind an environment switch;
+  - flip switch to legacy app as default if trigger conditions are met.
+- Data posture:
+  - Convex writes are append-first (events/logs) and kept for debugging;
+  - SQLite remains read-only legacy source during rollback window;
+  - no destructive backfill deletes during v1 rollout.
+- Verification after rollback:
+  - confirm legacy ops board loads;
+  - confirm existing snapshots/tasks remain visible in legacy path;
+  - record rollback incident in activity/log notes with root-cause owner.
 
 ## Ready for Execution
 - [ ] Scope approved: Tasks + Scheduler + Memory + Activity only.

--- a/ops_board/scripts/browser_smoke.sh
+++ b/ops_board/scripts/browser_smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PORT="${PORT:-3340}"
+URL="${1:-http://127.0.0.1:${PORT}}"
+DB_PATH="${DB_PATH:-$ROOT_DIR/ops_board/ops_board.browser-smoke.sqlite}"
+REPORT_DIR="${REPORT_DIR:-$ROOT_DIR/reports/browser-smoke}"
+SERVER_LOG="$REPORT_DIR/server.log"
+SCREENSHOT_PATH="$REPORT_DIR/ops-board-smoke.png"
+
+if ! command -v agent-browser >/dev/null 2>&1; then
+  echo "agent-browser CLI is required but not installed."
+  exit 1
+fi
+
+mkdir -p "$REPORT_DIR"
+
+PORT="$PORT" DB_PATH="$DB_PATH" node "$ROOT_DIR/ops_board/server.js" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+  agent-browser close >/dev/null 2>&1 || true
+  if kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+  if curl -fsS "$URL" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+curl -fsS "$URL" >/dev/null
+
+agent-browser open "$URL" >/dev/null
+TITLE="$(agent-browser get title)"
+SNAPSHOT="$(agent-browser snapshot -i)"
+
+echo "$TITLE" | grep -q "AgentDeck Ops Board"
+echo "$SNAPSHOT" | grep -q "Send Task"
+echo "$SNAPSHOT" | grep -q "Search sessions"
+
+agent-browser screenshot "$SCREENSHOT_PATH" >/dev/null
+echo "Browser smoke test passed. Screenshot: $SCREENSHOT_PATH"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,25 @@
         "better-sqlite3": "^12.6.2",
         "express": "^5.2.1",
         "ws": "^8.19.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/accepts": {
@@ -455,6 +474,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -791,6 +825,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,17 @@
     "ingest:dry": "node ops_board/scripts/ingest.js --dry-run",
     "snapshot": "node ops_board/scripts/snapshot.js",
     "start": "node ops_board/server.js",
-    "validate": "node ops_board/scripts/validate.js"
+    "validate": "node ops_board/scripts/validate.js",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:browser:smoke": "bash ops_board/scripts/browser_smoke.sh"
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",
     "express": "^5.2.1",
     "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,24 @@
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:3333",
+    headless: true,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command:
+      "PORT=3333 DB_PATH=./ops_board/ops_board.e2e.sqlite node ./ops_board/server.js",
+    url: "http://127.0.0.1:3333",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/ops-board.spec.js
+++ b/tests/e2e/ops-board.spec.js
@@ -1,0 +1,166 @@
+const { test, expect } = require("@playwright/test");
+
+function createState() {
+  return {
+    items: [
+      {
+        id: "item-1",
+        title: "Prepare migration checklist",
+        source: "mission-control",
+        kind: "task",
+        status: "today",
+        source_path: "dev_plans/agentdeck-mission-control-nextjs-convex-v1.md",
+        raw: "Lock v1 scope and publish plan updates.",
+        updated_at: "2026-02-18T18:00:00.000Z",
+      },
+      {
+        id: "item-2",
+        title: "Collect screenshots",
+        source: "briefly",
+        kind: "task",
+        status: "next",
+        source_path: "README.md",
+        raw: "Capture a short UI walkthrough.",
+        updated_at: "2026-02-18T18:10:00.000Z",
+      },
+    ],
+    sessions: [
+      {
+        id: "session-henry",
+        title: "Henry main",
+        agent: "Henry",
+        source: "gateway",
+        last_message: "Ready for new tasks",
+      },
+      {
+        id: "session-writer",
+        title: "Writer pod",
+        agent: "Writer",
+        source: "file",
+        last_message: "Drafting scripts",
+      },
+    ],
+    sentMessages: [],
+  };
+}
+
+async function mockApi(page, state) {
+  await page.route("**/api/items", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: state.items }),
+    });
+  });
+
+  await page.route("**/api/items/*/status", async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const pathParts = requestUrl.pathname.split("/");
+    const itemId = pathParts[pathParts.length - 2];
+    const payload = JSON.parse(route.request().postData() || "{}");
+    const item = state.items.find((entry) => entry.id === itemId);
+    if (item && payload.status) {
+      item.status = payload.status;
+      item.updated_at = new Date().toISOString();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Item not found" }),
+    });
+  });
+
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: state.sessions }),
+    });
+  });
+
+  await page.route("**/api/agents/*/send", async (route) => {
+    const payload = JSON.parse(route.request().postData() || "{}");
+    const requestUrl = new URL(route.request().url());
+    const pathParts = requestUrl.pathname.split("/");
+    const sessionId = pathParts[pathParts.length - 2];
+    state.sentMessages.push({
+      sessionId,
+      message: payload.message || "",
+      confirmed: Boolean(payload.confirmed),
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, runId: "run-123" }),
+    });
+  });
+}
+
+test("moves tasks across board columns", async ({ page }) => {
+  const state = createState();
+  await mockApi(page, state);
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "AgentDeck" })).toBeVisible();
+  await expect(page.locator("#today-list .card-title")).toContainText([
+    "Prepare migration checklist",
+  ]);
+  await expect(page.locator("#next-list .card-title")).toContainText([
+    "Collect screenshots",
+  ]);
+
+  const todayCard = page
+    .locator("#today-list .card")
+    .filter({ hasText: "Prepare migration checklist" });
+  await todayCard.getByRole("button", { name: "Mark Done" }).click();
+
+  await expect(page.locator("#done-list .card-title")).toContainText([
+    "Prepare migration checklist",
+  ]);
+});
+
+test("filters sessions and sends a task", async ({ page }) => {
+  const state = createState();
+  await mockApi(page, state);
+
+  await page.goto("/");
+  await expect(page.locator(".card.card--agent")).toHaveCount(2);
+
+  await page.fill("#agent-search", "writer");
+  await expect(page.locator(".card.card--agent")).toHaveCount(1);
+  await expect(page.locator(".card.card--agent .card-title")).toContainText([
+    "Writer",
+  ]);
+
+  await page.fill("#agent-search", "");
+  await expect(page.locator(".card.card--agent")).toHaveCount(2);
+
+  const henryCard = page
+    .locator(".card.card--agent")
+    .filter({ hasText: "Henry main" });
+  await henryCard.getByRole("button", { name: "Select" }).click();
+  await expect(page.locator("#selected-agent")).toContainText(
+    "Selected: Henry · session-henry",
+  );
+
+  await page.fill("#agent-message", "Ship the updated testing stack.");
+  page.once("dialog", async (dialog) => {
+    await dialog.accept();
+  });
+  await page.click("#agent-send-button");
+
+  await expect(page.locator("#agent-message")).toHaveValue("");
+  expect(state.sentMessages).toEqual([
+    {
+      sessionId: "session-henry",
+      message: "Ship the updated testing stack.",
+      confirmed: true,
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Align the Mission Control v1 plan to the original article inspiration.
- Keep v1 scope locked to Tasks, Scheduler, Memory, and Activity.
- Move Content Pipeline and Team to Phase 2, Office to Phase 3.
- Add explicit UI testing gates for any UI changes:
  - Playwright regression suite (`npm run test:e2e`)
  - Browser automation smoke flow (`npm run test:browser:smoke`)
- Add initial Playwright config/specs and an `agent-browser` smoke script.

## Plan Doc
- dev_plans/agentdeck-mission-control-nextjs-convex-v1.md

## Verification Run
- `npm run test:e2e` ✅ (2 tests passed)
- `npm run test:browser:smoke` ✅

## Notes
- `npm run validate` requires SOURCE_ROOT/ingest source paths and is expected to fail without env configuration.
